### PR TITLE
Configurable front-end Docker images

### DIFF
--- a/EMS-UI/Dockerfile
+++ b/EMS-UI/Dockerfile
@@ -1,15 +1,22 @@
 FROM node:10 AS builder
 
+# Build the distribution package
 RUN mkdir -p /app
 WORKDIR /app
-COPY package*.json /app/
+COPY package*.json ./
 RUN npm install
-COPY . /app/
-COPY src/environments/environment.prod.ts /app/src/environments/environment.ts
-RUN npm run build
+COPY . ./
+RUN npm run build:prod
 
 
+# Copy package to final image
 FROM nginx:alpine
 EXPOSE 4200
-COPY --from=builder /app/dist/cdss-ui /var/share/nginx/html
+WORKDIR /var/share/nginx/html
+COPY --from=builder /app/dist/cdss-ui ./
 COPY nginx.conf /etc/nginx/nginx.conf
+
+#Setup and execute startup script
+COPY run.sh ./
+RUN sed -i 's/\x0D$//' run.sh
+ENTRYPOINT ./run.sh

--- a/EMS-UI/angular.json
+++ b/EMS-UI/angular.json
@@ -41,10 +41,10 @@
               "sourceMap": false,
               "extractCss": true,
               "namedChunks": false,
-              "aot": true,
+              "aot": false,
               "extractLicenses": true,
               "vendorChunk": false,
-              "buildOptimizer": true
+              "buildOptimizer": false
             }
           }
         },

--- a/EMS-UI/package.json
+++ b/EMS-UI/package.json
@@ -5,6 +5,7 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build",
+    "build:prod": "ng build --prod",
     "test:ci": "ng test --watch=false --browsers=ChromeHeadlessCustom",
     "test": "ng test",
     "lint": "ng lint",

--- a/EMS-UI/run.sh
+++ b/EMS-UI/run.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+echo 'Substituting environment variables'
+
+# Set default values for environment variables
+export ENV_NAME="${ENV_NAME:-local}"
+export EMS_API="${EMS_API:-http://localhost:8083}"
+export UECDI_API="${UECDI_API:-http://localhost:5000}"
+export UECDI_VALIDATE_API="${UECDI_VALIDATE_API:-http://localhost:7000/tkw-client}"
+export TERM_API="${TERM_API:-https://ontoserver.dataproducts.nhs.uk/fhir}"
+
+# shellcheck disable=SC2016
+SUBST_VARS='$ENV_NAME,$EMS_API,$UECDI_API,$UECDI_VALIDATE_API,$TERM_API'
+
+TMP_FILE=$(mktemp)
+SUBST_FILE=$(ls main.*.js)
+chmod go+w "$SUBST_FILE"
+
+# Substitute specified environment variables
+envsubst "$SUBST_VARS" <"$SUBST_FILE" >"$TMP_FILE"
+mv "$TMP_FILE" "$SUBST_FILE"
+
+# Start nginx server
+echo "Starting Angular app in nginx on $HOSTNAME"
+nginx -g "daemon off;"

--- a/EMS-UI/src/environments/environment.prod.ts
+++ b/EMS-UI/src/environments/environment.prod.ts
@@ -1,7 +1,8 @@
+// The values in this file will be replaced with environment variables in run.sh
 export const environment = {
-  production: true,
-  EMS_API: 'https://ems.cactus-staging.iucdspilot.uk',
-  UECDI_API: 'http://emstestharness-ems-care-advice.eu-west-2.elasticbeanstalk.com',
-  UECDI_VALIDATE_API: 'http://uecdi-tom-tkw.eu-west-2.elasticbeanstalk.com/tkw-client',
-  TERM_API: 'https://ontoserver.dataproducts.nhs.uk/fhir',
+  ENV_NAME: '$ENV_NAME',
+  EMS_API: '$EMS_API',
+  UECDI_API: '$UECDI_API',
+  UECDI_VALIDATE_API: '$UECDI_VALIDATE_API',
+  TERM_API: '$TERM_API',
 };

--- a/EMS-UI/src/environments/environment.ts
+++ b/EMS-UI/src/environments/environment.ts
@@ -1,8 +1,7 @@
-// This file can be replaced during build by using the `fileReplacements` array.
-// `ng build ---prod` replaces `environment.ts` with `environment.prod.ts`.
-// The list of file replacements can be found in `angular.json`.
+// `ng build ---prod` replaces this file with `environment.prod.ts`
+// via config provided in angular.json
 export const environment = {
-  production: false,
+  ENV_NAME: 'local',
   EMS_API: 'http://localhost:8083',
   UECDI_API: 'http://localhost:5000',
   UECDI_VALIDATE_API: 'http://localhost:7000/tkw-client',

--- a/EMS-UI/src/main.ts
+++ b/EMS-UI/src/main.ts
@@ -4,7 +4,7 @@ import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { AppModule } from './app/app.module';
 import { environment } from './environments/environment';
 
-if (environment.production) {
+if (environment.ENV_NAME !== 'local') {
   enableProdMode();
 }
 


### PR DESCRIPTION
Added a way for docker container environment variables to replace front-end connection URLs in the already-built image.

Running `ng serve` or `ng build` will still, as before, serve or build a frontend that points to a local EMS backend (as defined in `environment.ts`).
However, running `ng build --prod` (aliased as `npm run build:prod`) will use the `production` configuration settings from `angular.json`, which will replace `environment.ts` with `environment.prod.ts`, which only contains placeholders that can be replaced in the resulting `dist/cdss-ui/main.*.js` file.
The substitution happens in `EMS-UI/run.sh`, which collects the necessary environment variables (falling back on the local URLs if missing), replaces the placeholders and starts the nginx server.

This is relevant if you're running the front-end from the built docker image and it allows us to specify which EMS the front-end should connect to when running the image (without rebuilding) as follows:
```bash
docker run -p 4200:4200 -e ENV_NAME=staging -e -EMS_API=https://ems.cactus-staging.iucdspilot.uk (...) cactus-ems-ui:latest
```
Environment variable names can be alternatively specified using the `--env-file` `docker run` option.