### PR TITLE
Feature/cdsct 195 add supplier tokens requests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
     <elastic-search-version>7.7.1</elastic-search-version>
 
-    <cactus-common.version>0.0.4</cactus-common.version>
+    <cactus-common.version>0.0.5.1</cactus-common.version>
   </properties>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -242,6 +242,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.github.npathai</groupId>
+      <artifactId>hamcrest-optional</artifactId>
+      <version>2.0.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.skyscreamer</groupId>
       <artifactId>jsonassert</artifactId>
       <version>1.5.0</version>

--- a/src/main/java/uk/nhs/ctp/config/FHIRConfig.java
+++ b/src/main/java/uk/nhs/ctp/config/FHIRConfig.java
@@ -8,7 +8,6 @@ import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.rest.client.interceptor.BearerTokenAuthInterceptor;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import javax.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.hl7.fhir.dstu3.model.CareConnectCarePlan;
@@ -31,14 +30,14 @@ import org.hl7.fhir.dstu3.model.CoordinateResource;
 import org.hl7.fhir.dstu3.model.Resource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.core.context.SecurityContextHolder;
-import uk.nhs.cactus.common.security.CactusToken;
+import uk.nhs.ctp.security.SupplierTokenResolver;
 
 @Configuration
 @RequiredArgsConstructor
 public class FHIRConfig {
 
   private final List<IClientInterceptor> clientInterceptors;
+  private final SupplierTokenResolver tokenResolver;
 
   @Bean
   public FhirContext fhirContext() {
@@ -86,10 +85,8 @@ public class FHIRConfig {
         }
 
         // Authentication
-        // TODO match base URL to configurable authentication per service
-        Optional.ofNullable(SecurityContextHolder.getContext().getAuthentication())
-            .map(auth -> (CactusToken) auth.getCredentials())
-            .map(credentials -> new BearerTokenAuthInterceptor(credentials.getToken()))
+        tokenResolver.resolve(theServerBase)
+            .map(BearerTokenAuthInterceptor::new)
             .ifPresent(client::registerInterceptor);
 
         return client;

--- a/src/main/java/uk/nhs/ctp/config/interceptors/AuthRestClient.java
+++ b/src/main/java/uk/nhs/ctp/config/interceptors/AuthRestClient.java
@@ -1,18 +1,18 @@
 package uk.nhs.ctp.config.interceptors;
 
 import java.io.IOException;
-import java.util.Optional;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpRequest;
 import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.http.client.ClientHttpResponse;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
-import uk.nhs.cactus.common.security.CactusToken;
+import uk.nhs.ctp.security.SupplierTokenResolver;
 
 @Component
+@RequiredArgsConstructor
 public class AuthRestClient implements ClientHttpRequestInterceptor {
 
   @Value("${blob.server}")
@@ -21,14 +21,14 @@ public class AuthRestClient implements ClientHttpRequestInterceptor {
   @Value("${blob.server.auth.token}")
   private String blobServerAuthToken;
 
+  private final SupplierTokenResolver tokenResolver;
+
   @Override
   public ClientHttpResponse intercept(HttpRequest request, byte[] body,
       ClientHttpRequestExecution execution) throws IOException {
 
-    // TODO match base URL to configurable authentication per service
-    Optional.ofNullable(SecurityContextHolder.getContext().getAuthentication())
-        .map(auth -> (CactusToken) auth.getCredentials())
-        .map(credentials -> "Bearer " + credentials.getToken())
+    tokenResolver.resolve(request.getURI().toString())
+        .map(token -> "Bearer " + token)
         .ifPresent(token -> request.getHeaders().set(HttpHeaders.AUTHORIZATION, token));
 
     return execution.execute(request, body);

--- a/src/main/java/uk/nhs/ctp/entities/CdssSupplier.java
+++ b/src/main/java/uk/nhs/ctp/entities/CdssSupplier.java
@@ -20,7 +20,11 @@ import uk.nhs.ctp.enums.ReferencingType;
 
 @EqualsAndHashCode(callSuper = true)
 @Entity
-@Table(name = "cdss_supplier", indexes = @Index(columnList = "supplierId"))
+@Table(name = "cdss_supplier",
+    indexes = {
+      @Index(columnList = "supplierId"),
+      @Index(columnList = "supplierId,base_url"),
+    })
 @Data
 public class CdssSupplier extends SupplierPartitioned {
 

--- a/src/main/java/uk/nhs/ctp/entities/EmsSupplier.java
+++ b/src/main/java/uk/nhs/ctp/entities/EmsSupplier.java
@@ -11,7 +11,11 @@ import lombok.Data;
 
 @Data
 @Entity
-@Table(name = "ems_supplier", indexes = @Index(columnList = "supplierId"))
+@Table(name = "ems_supplier",
+    indexes = {
+        @Index(columnList = "supplierId"),
+        @Index(columnList = "supplierId,base_url"),
+    })
 public class EmsSupplier extends SupplierPartitioned {
 
   @Id

--- a/src/main/java/uk/nhs/ctp/model/SupplierAccountDetails.java
+++ b/src/main/java/uk/nhs/ctp/model/SupplierAccountDetails.java
@@ -17,6 +17,7 @@ public class SupplierAccountDetails {
   @Builder
   public static class EndpointDetails {
     String cdss;
+    String cdss2;
     String ems;
     String emsUi;
     String dos;

--- a/src/main/java/uk/nhs/ctp/repos/CdssSupplierRepository.java
+++ b/src/main/java/uk/nhs/ctp/repos/CdssSupplierRepository.java
@@ -1,9 +1,12 @@
 package uk.nhs.ctp.repos;
 
+import java.util.Optional;
 import org.springframework.stereotype.Repository;
 import uk.nhs.ctp.entities.CdssSupplier;
 
 @Repository
 public interface CdssSupplierRepository extends PartitionedRepository<CdssSupplier, Long> {
+
+  Optional<CdssSupplier> getOneBySupplierIdAndBaseUrl(String supplierId, String baseUrl);
 
 }

--- a/src/main/java/uk/nhs/ctp/repos/EmsSupplierRepository.java
+++ b/src/main/java/uk/nhs/ctp/repos/EmsSupplierRepository.java
@@ -1,9 +1,12 @@
 package uk.nhs.ctp.repos;
 
+import java.util.Optional;
 import org.springframework.stereotype.Repository;
 import uk.nhs.ctp.entities.EmsSupplier;
 
 @Repository
 public interface EmsSupplierRepository extends PartitionedRepository<EmsSupplier, Long> {
+
+  Optional<EmsSupplier> getOneBySupplierIdAndBaseUrl(String supplierId, String baseUrl);
 
 }

--- a/src/main/java/uk/nhs/ctp/security/SupplierTokenResolver.java
+++ b/src/main/java/uk/nhs/ctp/security/SupplierTokenResolver.java
@@ -27,9 +27,6 @@ public class SupplierTokenResolver {
   @Value("${ems.fhir.server}")
   private String emsFhirServer;
 
-  @Value("${cactus.cdss}")
-  private String cactusCdss;
-
   @Value("${dos.server}")
   private String dosServer;
 
@@ -48,7 +45,7 @@ public class SupplierTokenResolver {
    */
   public Optional<String> resolve(String requestUrl) {
     final List<String> cactusServices =
-        Arrays.asList(fhirServer, blobServer, emsFhirServer, cactusCdss, dosServer);
+        Arrays.asList(fhirServer, blobServer, emsFhirServer, dosServer);
 
     if (cactusServices.stream().anyMatch(requestUrl::startsWith)) {
       return Optional.ofNullable(SecurityContextHolder.getContext().getAuthentication())

--- a/src/main/java/uk/nhs/ctp/security/SupplierTokenResolver.java
+++ b/src/main/java/uk/nhs/ctp/security/SupplierTokenResolver.java
@@ -1,0 +1,47 @@
+package uk.nhs.ctp.security;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import uk.nhs.cactus.common.security.CactusToken;
+
+@Component
+@RequiredArgsConstructor
+public class SupplierTokenResolver {
+
+  @Value("${fhir.server}")
+  private String fhirServer;
+
+  @Value("${blob.server}")
+  private String blobServer;
+
+  @Value("${ems.fhir.server}")
+  private String emsFhirServer;
+
+  @Value("${cactus.cdss}")
+  private String cactusCdss;
+
+  @Value("${dos.server}")
+  private String dosServer;
+
+  public Optional<String> resolve(String requestUrl) {
+    final List<String> cactusServices =
+        Arrays.asList(fhirServer, blobServer, emsFhirServer, cactusCdss, dosServer);
+
+    boolean isCactus = cactusServices.stream()
+        .anyMatch(requestUrl::startsWith);
+
+    if (isCactus) {
+      return Optional.ofNullable(SecurityContextHolder.getContext().getAuthentication())
+          .map(auth -> (CactusToken) auth.getCredentials())
+          .map(CactusToken::getToken);
+    }
+
+    return Optional.empty();
+  }
+
+}

--- a/src/main/java/uk/nhs/ctp/security/SupplierTokenResolver.java
+++ b/src/main/java/uk/nhs/ctp/security/SupplierTokenResolver.java
@@ -3,11 +3,16 @@ package uk.nhs.ctp.security;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import uk.nhs.cactus.common.security.CactusToken;
+import uk.nhs.ctp.entities.CdssSupplier;
+import uk.nhs.ctp.entities.EmsSupplier;
+import uk.nhs.ctp.service.CdssSupplierService;
+import uk.nhs.ctp.service.EmsSupplierService;
 
 @Component
 @RequiredArgsConstructor
@@ -28,20 +33,36 @@ public class SupplierTokenResolver {
   @Value("${dos.server}")
   private String dosServer;
 
+  private final CdssSupplierService cdssSupplierService;
+  private final EmsSupplierService emsSupplierService;
+
+  /**
+   * Returns an auth token based on the URL for the request.
+   * This method looks up tokens with the following precedence:
+   * 1. If the request URL is for a CACTUS service, a cactus token will be returned.
+   * 2. If the request URL is for a registered CDSS or EMS, the token for that service will be returned.
+   * 3. An empty optional.
+   *
+   * @param requestUrl the service being requested
+   * @return the token for that service.
+   */
   public Optional<String> resolve(String requestUrl) {
     final List<String> cactusServices =
         Arrays.asList(fhirServer, blobServer, emsFhirServer, cactusCdss, dosServer);
 
-    boolean isCactus = cactusServices.stream()
-        .anyMatch(requestUrl::startsWith);
-
-    if (isCactus) {
+    if (cactusServices.stream().anyMatch(requestUrl::startsWith)) {
       return Optional.ofNullable(SecurityContextHolder.getContext().getAuthentication())
           .map(auth -> (CactusToken) auth.getCredentials())
           .map(CactusToken::getToken);
     }
 
-    return Optional.empty();
+    Supplier<Optional<String>> emsProviderAuthTokenSupplier = () -> emsSupplierService
+        .findEmsSupplierByBaseUrl(requestUrl)
+        .map(EmsSupplier::getAuthToken);
+    return cdssSupplierService.findCdssSupplierByBaseUrl(requestUrl)
+        .map(CdssSupplier::getAuthToken)
+        .or(emsProviderAuthTokenSupplier);
+
   }
 
 }

--- a/src/main/java/uk/nhs/ctp/service/CdssSupplierService.java
+++ b/src/main/java/uk/nhs/ctp/service/CdssSupplierService.java
@@ -1,6 +1,9 @@
 package uk.nhs.ctp.service;
 
+import static com.google.common.collect.MoreCollectors.toOptional;
+
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -59,6 +62,12 @@ public class CdssSupplierService {
   public CdssSupplier getCdssSupplier(Long id) {
     return cdssSupplierRepository.getOneByIdAndSupplierId(id, authService.requireSupplierId())
         .orElseThrow(EMSException::notFound);
+  }
+
+  public Optional<CdssSupplier> findCdssSupplierByBaseUrl(String baseUrl) {
+    return cdssSupplierRepository.findAllBySupplierId(authService.requireSupplierId()).stream()
+        .filter(supplier -> supplier.getBaseUrl().equals(baseUrl))
+        .collect(toOptional());
   }
 
   public CdssSupplier createCdssSupplier(NewCdssSupplierDTO newCdssSupplierDTO) {

--- a/src/main/java/uk/nhs/ctp/service/CdssSupplierService.java
+++ b/src/main/java/uk/nhs/ctp/service/CdssSupplierService.java
@@ -1,7 +1,5 @@
 package uk.nhs.ctp.service;
 
-import static com.google.common.collect.MoreCollectors.toOptional;
-
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -65,9 +63,8 @@ public class CdssSupplierService {
   }
 
   public Optional<CdssSupplier> findCdssSupplierByBaseUrl(String baseUrl) {
-    return cdssSupplierRepository.findAllBySupplierId(authService.requireSupplierId()).stream()
-        .filter(supplier -> supplier.getBaseUrl().equals(baseUrl))
-        .collect(toOptional());
+    return cdssSupplierRepository
+        .getOneBySupplierIdAndBaseUrl(authService.requireSupplierId(), baseUrl);
   }
 
   public CdssSupplier createCdssSupplier(NewCdssSupplierDTO newCdssSupplierDTO) {

--- a/src/main/java/uk/nhs/ctp/service/EmsSupplierService.java
+++ b/src/main/java/uk/nhs/ctp/service/EmsSupplierService.java
@@ -1,7 +1,5 @@
 package uk.nhs.ctp.service;
 
-import static com.google.common.collect.MoreCollectors.toOptional;
-
 import java.util.List;
 import java.util.Optional;
 import javax.transaction.Transactional;
@@ -25,9 +23,8 @@ public class EmsSupplierService {
   }
 
   public Optional<EmsSupplier> findEmsSupplierByBaseUrl(String baseUrl) {
-    return emsSupplierRepository.findAllBySupplierId(authService.requireSupplierId()).stream()
-        .filter(supplier -> supplier.getBaseUrl().equals(baseUrl))
-        .collect(toOptional());
+    return emsSupplierRepository
+        .getOneBySupplierIdAndBaseUrl(authService.requireSupplierId(), baseUrl);
   }
 
   public EmsSupplier crupdate(EmsSupplier updated) {

--- a/src/main/java/uk/nhs/ctp/service/EmsSupplierService.java
+++ b/src/main/java/uk/nhs/ctp/service/EmsSupplierService.java
@@ -1,6 +1,9 @@
 package uk.nhs.ctp.service;
 
+import static com.google.common.collect.MoreCollectors.toOptional;
+
 import java.util.List;
+import java.util.Optional;
 import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,6 +22,12 @@ public class EmsSupplierService {
   public List<EmsSupplier> getAll() {
     return emsSupplierRepository
         .findAllBySupplierId(authService.requireSupplierId());
+  }
+
+  public Optional<EmsSupplier> findEmsSupplierByBaseUrl(String baseUrl) {
+    return emsSupplierRepository.findAllBySupplierId(authService.requireSupplierId()).stream()
+        .filter(supplier -> supplier.getBaseUrl().equals(baseUrl))
+        .collect(toOptional());
   }
 
   public EmsSupplier crupdate(EmsSupplier updated) {

--- a/src/main/java/uk/nhs/ctp/service/UserManagementService.java
+++ b/src/main/java/uk/nhs/ctp/service/UserManagementService.java
@@ -43,6 +43,9 @@ public class UserManagementService {
   @Value("${cactus.cdss}")
   private String cdss;
 
+  @Value("${cactus.cdss.v2}")
+  private String cdss2;
+
   @Value("${dos.server}")
   private String dos;
 
@@ -78,6 +81,7 @@ public class UserManagementService {
               .ems(ems)
               .emsUi(emsUi)
               .cdss(cdss)
+              .cdss2(cdss2)
               .dos(dos)
               .logs(logs)
               .build())

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -28,6 +28,7 @@ ems.frontend=http://localhost:4200
 
 # supplier integration
 cactus.cdss=http://localhost:8080/fhir
+cactus.cdss.v2=http://localhost:8080/fhir
 logs.server=http://elastic.search
 cognito.user.pool=
 cactus.jwt.secret=local_only_not_so_secret

--- a/src/test/java/uk/nhs/ctp/controllers/UserControllerTest.java
+++ b/src/test/java/uk/nhs/ctp/controllers/UserControllerTest.java
@@ -64,6 +64,7 @@ public class UserControllerTest {
         .email("testemail")
         .endpoints(EndpointDetails.builder()
             .cdss("http://localhost:8080/fhir")
+            .cdss2("http://localhost:8080/fhir")
             .ems("http://localhost:8083/fhir")
             .emsUi("http://localhost:4200")
             .dos("http://localhost:8085/fhir")

--- a/src/test/java/uk/nhs/ctp/security/SupplierTokenResolverTest.java
+++ b/src/test/java/uk/nhs/ctp/security/SupplierTokenResolverTest.java
@@ -44,7 +44,6 @@ public class SupplierTokenResolverTest {
     ReflectionTestUtils.setField(tokenResolver, "fhirServer", "fhir.server");
     ReflectionTestUtils.setField(tokenResolver, "blobServer", "blob.server");
     ReflectionTestUtils.setField(tokenResolver, "emsFhirServer", "ems.fhir.server");
-    ReflectionTestUtils.setField(tokenResolver, "cactusCdss", "cdss.server");
     ReflectionTestUtils.setField(tokenResolver, "dosServer", "dos.server");
   }
 

--- a/src/test/java/uk/nhs/ctp/security/SupplierTokenResolverTest.java
+++ b/src/test/java/uk/nhs/ctp/security/SupplierTokenResolverTest.java
@@ -64,11 +64,6 @@ public class SupplierTokenResolverTest {
   }
 
   @Test
-  public void resolveToken_UrlMatchesCactusCdssServer() {
-    resolveCactusTest("cdss.server");
-  }
-
-  @Test
   public void resolveToken_UrlMatchesCactusDosServer() {
     resolveCactusTest("dos.server");
   }

--- a/src/test/java/uk/nhs/ctp/security/SupplierTokenResolverTest.java
+++ b/src/test/java/uk/nhs/ctp/security/SupplierTokenResolverTest.java
@@ -1,0 +1,131 @@
+package uk.nhs.ctp.security;
+
+import static com.github.npathai.hamcrestopt.OptionalMatchers.isEmpty;
+import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresentAndIs;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.util.ReflectionTestUtils;
+import uk.nhs.cactus.common.security.CactusToken;
+import uk.nhs.ctp.entities.CdssSupplier;
+import uk.nhs.ctp.entities.EmsSupplier;
+import uk.nhs.ctp.service.CdssSupplierService;
+import uk.nhs.ctp.service.EmsSupplierService;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SupplierTokenResolverTest {
+
+  @InjectMocks
+  private SupplierTokenResolver tokenResolver;
+
+  @Mock
+  private CdssSupplierService cdssSupplierService;
+  @Mock
+  private EmsSupplierService emsSupplierService;
+  @Mock
+  private SecurityContext securityContext;
+  @Mock
+  private Authentication authentication;
+
+  @Before
+  public void setup() {
+    ReflectionTestUtils.setField(tokenResolver, "fhirServer", "fhir.server");
+    ReflectionTestUtils.setField(tokenResolver, "blobServer", "blob.server");
+    ReflectionTestUtils.setField(tokenResolver, "emsFhirServer", "ems.fhir.server");
+    ReflectionTestUtils.setField(tokenResolver, "cactusCdss", "cdss.server");
+    ReflectionTestUtils.setField(tokenResolver, "dosServer", "dos.server");
+  }
+
+  @Test
+  public void resolveToken_UrlMatchesCactusFhirServer() {
+    resolveCactusTest("fhir.server");
+  }
+
+  @Test
+  public void resolveToken_UrlMatchesCactusBlobServer() {
+    resolveCactusTest("blob.server");
+  }
+
+  @Test
+  public void resolveToken_UrlMatchesCactusEmsFhirServer() {
+    resolveCactusTest("ems.fhir.server");
+  }
+
+  @Test
+  public void resolveToken_UrlMatchesCactusCdssServer() {
+    resolveCactusTest("cdss.server");
+  }
+
+  @Test
+  public void resolveToken_UrlMatchesCactusDosServer() {
+    resolveCactusTest("dos.server");
+  }
+
+  private void resolveCactusTest(String url) {
+    CactusToken cactusToken = new CactusToken("fake.token", null);
+    when(authentication.getCredentials()).thenReturn(cactusToken);
+    when(securityContext.getAuthentication()).thenReturn(authentication);
+    SecurityContextHolder.setContext(securityContext);
+
+    Optional<String> resolved = tokenResolver.resolve(url);
+    assertThat(resolved, isPresentAndIs("fake.token"));
+    verifyZeroInteractions(cdssSupplierService, emsSupplierService);
+  }
+
+  @Test
+  public void resolveToken_UrlMatchesCdssSupplier() {
+    CdssSupplier supplier = new CdssSupplier();
+    supplier.setBaseUrl("cdss.url");
+    supplier.setAuthToken("cdss.auth.token");
+    when(cdssSupplierService.findCdssSupplierByBaseUrl("cdss.url"))
+        .thenReturn(Optional.of(supplier));
+
+    Optional<String> resolved = tokenResolver.resolve("cdss.url");
+
+    assertThat(resolved, isPresentAndIs("cdss.auth.token"));
+    verifyZeroInteractions(emsSupplierService, securityContext);
+  }
+
+  @Test
+  public void resolveToken_UrlMatchesEmsSupplier() {
+    EmsSupplier supplier = new EmsSupplier();
+    supplier.setBaseUrl("ems.url");
+    supplier.setAuthToken("ems.auth.token");
+
+    when(cdssSupplierService.findCdssSupplierByBaseUrl(any()))
+        .thenReturn(Optional.empty());
+    when(emsSupplierService.findEmsSupplierByBaseUrl("ems.url"))
+        .thenReturn(Optional.of(supplier));
+
+    Optional<String> resolved = tokenResolver.resolve("ems.url");
+
+    assertThat(resolved, isPresentAndIs("ems.auth.token"));
+    verifyZeroInteractions( securityContext);
+  }
+
+  @Test
+  public void resolveToken_noMatch() {
+
+    when(cdssSupplierService.findCdssSupplierByBaseUrl(any()))
+        .thenReturn(Optional.empty());
+    when(emsSupplierService.findEmsSupplierByBaseUrl(any()))
+        .thenReturn(Optional.empty());
+
+    Optional<String> resolved = tokenResolver.resolve("not.known");
+
+    assertThat(resolved, isEmpty());
+    verifyZeroInteractions( securityContext);
+  }
+}

--- a/src/test/java/uk/nhs/ctp/service/CdssSupplierServiceTest.java
+++ b/src/test/java/uk/nhs/ctp/service/CdssSupplierServiceTest.java
@@ -13,7 +13,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -203,10 +202,8 @@ public class CdssSupplierServiceTest {
   public void testFindCdssSupplierByUrl_matches() {
     CdssSupplier matched = new CdssSupplier();
     matched.setBaseUrl("matched.base");
-    CdssSupplier notMatched = new CdssSupplier();
-    notMatched.setBaseUrl("not.matched.base");
-    when(cdssSupplierRepository.findAllBySupplierId(SUPPLIER))
-        .thenReturn(Arrays.asList(matched, notMatched));
+    when(cdssSupplierRepository.getOneBySupplierIdAndBaseUrl(SUPPLIER, "matched.base"))
+        .thenReturn(Optional.of(matched));
 
     Optional<CdssSupplier> found = cdssSupplierService
         .findCdssSupplierByBaseUrl("matched.base");
@@ -216,29 +213,13 @@ public class CdssSupplierServiceTest {
 
   @Test
   public void testFindCdssSupplierByUrl_noMatches() {
-    CdssSupplier notMatched = new CdssSupplier();
-    notMatched.setBaseUrl("not.matched.base");
-    when(cdssSupplierRepository.findAllBySupplierId(SUPPLIER))
-        .thenReturn(Collections.singletonList(notMatched));
+    when(cdssSupplierRepository.getOneBySupplierIdAndBaseUrl(SUPPLIER, "matched.base"))
+        .thenReturn(Optional.empty());
 
     Optional<CdssSupplier> found = cdssSupplierService
         .findCdssSupplierByBaseUrl("matched.base");
 
     assertThat(found, isEmpty());
-  }
-
-  @Test
-  public void testFindCdssSupplierByUrl_multipleMatches_throws() {
-    CdssSupplier matched = new CdssSupplier();
-    matched.setBaseUrl("matched.base");
-    CdssSupplier matched2 = new CdssSupplier();
-    matched2.setBaseUrl("matched.base");
-    when(cdssSupplierRepository.findAllBySupplierId(SUPPLIER))
-        .thenReturn(Arrays.asList(matched, matched2));
-
-    expectedException.expect(IllegalArgumentException.class);
-
-    cdssSupplierService.findCdssSupplierByBaseUrl("matched.base");
   }
 
 }

--- a/src/test/java/uk/nhs/ctp/service/CompositionServiceTest.java
+++ b/src/test/java/uk/nhs/ctp/service/CompositionServiceTest.java
@@ -93,7 +93,7 @@ public class CompositionServiceTest {
 
   @Before
   public void setup() {
-    fhirContext = new FHIRConfig(null).fhirContext();
+    fhirContext = new FHIRConfig(null, null).fhirContext();
     when(mockedFhirContext.newJsonParser()).thenReturn(fhirContext.newJsonParser());
 
     buildInterimCase();

--- a/src/test/java/uk/nhs/ctp/service/EmsSupplierServiceTest.java
+++ b/src/test/java/uk/nhs/ctp/service/EmsSupplierServiceTest.java
@@ -5,8 +5,6 @@ import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresentAndIs;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.Optional;
 import org.junit.Before;
 import org.junit.Rule;
@@ -45,10 +43,8 @@ public class EmsSupplierServiceTest {
   public void testFindCdssSupplierByUrl_matches() {
     EmsSupplier matched = new EmsSupplier();
     matched.setBaseUrl("matched.base");
-    EmsSupplier notMatched = new EmsSupplier();
-    notMatched.setBaseUrl("not.matched.base");
-    when(emsSupplierRepository.findAllBySupplierId(SUPPLIER))
-        .thenReturn(Arrays.asList(matched, notMatched));
+    when(emsSupplierRepository.getOneBySupplierIdAndBaseUrl(SUPPLIER, "matched.base"))
+        .thenReturn(Optional.of(matched));
 
     Optional<EmsSupplier> found = emsSupplierService
         .findEmsSupplierByBaseUrl("matched.base");
@@ -58,29 +54,12 @@ public class EmsSupplierServiceTest {
 
   @Test
   public void testFindCdssSupplierByUrl_noMatches() {
-    EmsSupplier notMatched = new EmsSupplier();
-    notMatched.setBaseUrl("not.matched.base");
-    when(emsSupplierRepository.findAllBySupplierId(SUPPLIER))
-        .thenReturn(Collections.singletonList(notMatched));
+    when(emsSupplierRepository.getOneBySupplierIdAndBaseUrl(SUPPLIER, "matched.base"))
+        .thenReturn(Optional.empty());
 
     Optional<EmsSupplier> found = emsSupplierService
         .findEmsSupplierByBaseUrl("matched.base");
 
     assertThat(found, isEmpty());
   }
-
-  @Test
-  public void testFindCdssSupplierByUrl_multipleMatches_throws() {
-    EmsSupplier matched = new EmsSupplier();
-    matched.setBaseUrl("matched.base");
-    EmsSupplier matched2 = new EmsSupplier();
-    matched2.setBaseUrl("matched.base");
-    when(emsSupplierRepository.findAllBySupplierId(SUPPLIER))
-        .thenReturn(Arrays.asList(matched, matched2));
-
-    expectedException.expect(IllegalArgumentException.class);
-
-    emsSupplierService.findEmsSupplierByBaseUrl("matched.base");
-  }
-
 }

--- a/src/test/java/uk/nhs/ctp/service/EmsSupplierServiceTest.java
+++ b/src/test/java/uk/nhs/ctp/service/EmsSupplierServiceTest.java
@@ -1,0 +1,86 @@
+package uk.nhs.ctp.service;
+
+import static com.github.npathai.hamcrestopt.OptionalMatchers.isEmpty;
+import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresentAndIs;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import uk.nhs.cactus.common.security.TokenAuthenticationService;
+import uk.nhs.ctp.entities.EmsSupplier;
+import uk.nhs.ctp.repos.EmsSupplierRepository;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EmsSupplierServiceTest {
+
+  private static final String SUPPLIER = "supplier";
+
+  @InjectMocks
+  private EmsSupplierService emsSupplierService;
+
+  @Mock
+  private EmsSupplierRepository emsSupplierRepository;
+  @Mock
+  private TokenAuthenticationService authService;
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  @Before
+  public void setup() {
+    when(authService.requireSupplierId()).thenReturn(SUPPLIER);
+  }
+
+  @Test
+  public void testFindCdssSupplierByUrl_matches() {
+    EmsSupplier matched = new EmsSupplier();
+    matched.setBaseUrl("matched.base");
+    EmsSupplier notMatched = new EmsSupplier();
+    notMatched.setBaseUrl("not.matched.base");
+    when(emsSupplierRepository.findAllBySupplierId(SUPPLIER))
+        .thenReturn(Arrays.asList(matched, notMatched));
+
+    Optional<EmsSupplier> found = emsSupplierService
+        .findEmsSupplierByBaseUrl("matched.base");
+
+    assertThat(found, isPresentAndIs(matched));
+  }
+
+  @Test
+  public void testFindCdssSupplierByUrl_noMatches() {
+    EmsSupplier notMatched = new EmsSupplier();
+    notMatched.setBaseUrl("not.matched.base");
+    when(emsSupplierRepository.findAllBySupplierId(SUPPLIER))
+        .thenReturn(Collections.singletonList(notMatched));
+
+    Optional<EmsSupplier> found = emsSupplierService
+        .findEmsSupplierByBaseUrl("matched.base");
+
+    assertThat(found, isEmpty());
+  }
+
+  @Test
+  public void testFindCdssSupplierByUrl_multipleMatches_throws() {
+    EmsSupplier matched = new EmsSupplier();
+    matched.setBaseUrl("matched.base");
+    EmsSupplier matched2 = new EmsSupplier();
+    matched2.setBaseUrl("matched.base");
+    when(emsSupplierRepository.findAllBySupplierId(SUPPLIER))
+        .thenReturn(Arrays.asList(matched, matched2));
+
+    expectedException.expect(IllegalArgumentException.class);
+
+    emsSupplierService.findEmsSupplierByBaseUrl("matched.base");
+  }
+
+}

--- a/src/test/java/uk/nhs/ctp/service/UserManagementServiceTest.java
+++ b/src/test/java/uk/nhs/ctp/service/UserManagementServiceTest.java
@@ -72,6 +72,7 @@ public class UserManagementServiceTest {
     ReflectionTestUtils.setField(userManagementService, "ems", "http://ems.com");
     ReflectionTestUtils.setField(userManagementService, "emsUi", "http://ems-ui.com");
     ReflectionTestUtils.setField(userManagementService, "cdss", "http://cdss.com");
+    ReflectionTestUtils.setField(userManagementService, "cdss2", "http://cdss2.com");
     ReflectionTestUtils.setField(userManagementService, "dos", "http://dos.com");
     ReflectionTestUtils.setField(userManagementService, "logs", "http://elastic.com");
 
@@ -87,6 +88,7 @@ public class UserManagementServiceTest {
             .ems("http://ems.com")
             .emsUi("http://ems-ui.com")
             .cdss("http://cdss.com")
+            .cdss2("http://cdss2.com")
             .dos("http://dos.com")
             .logs("http://elastic.com")
             .build())


### PR DESCRIPTION
Look up the relevant token to use when making fhir/rest requests from inside the EMS.
Some things to note:
- Cactus services take precedence, followed by registered suppliers. If neither are present, no token is used.
- Still unsure of how to do any real higher level testing 