### PR TITLE
Feature/cdsct 277 report creation ui

### DIFF
--- a/EMS-UI/src/app/app-routing.module.ts
+++ b/EMS-UI/src/app/app-routing.module.ts
@@ -1,3 +1,4 @@
+import { ValidationReportComponent } from './validation-report/validation-report.component';
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { LoginComponent } from './login/login.component';
@@ -34,7 +35,8 @@ const routes: Routes = [
   { path: 'settings', component: ManageSettingsComponent, canActivate: [AuthGuard]  },
   { path: 'triage', component: TriageComponent, canActivate: [AuthGuard]  },
   { path: 'account/password', component: ResetPasswordComponent, canActivate: [AuthGuard]  },
-  { path: 'view-audits', component: ViewAuditsComponent, canActivate: [AuthGuard]  }
+  { path: 'view-audits', component: ViewAuditsComponent, canActivate: [AuthGuard]  },
+  { path: 'create_report', component: ValidationReportComponent, canActivate: [AuthGuard]}
 ];
 
 @NgModule({

--- a/EMS-UI/src/app/app.module.ts
+++ b/EMS-UI/src/app/app.module.ts
@@ -65,6 +65,7 @@ import { EnvironmentService } from './service/environment.service';
 import { EmsSupplierComponent, EditEmsDialog } from './supplier-managment/ems-supplier/ems-supplier.component';
 import { EmsService } from './service/ems.service';
 import { ReportSearchDialogComponent } from './main/report-search-dialog/report-search-dialog.component';
+import { ValidationReportComponent } from './validation-report/validation-report.component';
 
 export function hljsLanguages() {
   return [
@@ -113,7 +114,8 @@ export function hljsLanguages() {
     PractitionerSelectionComponent,
     EmsSupplierComponent,
     EditEmsDialog,
-    ReportSearchDialogComponent
+    ReportSearchDialogComponent,
+    ValidationReportComponent
   ],
   entryComponents: [
     SwitchSupplierDialogComponent, 

--- a/EMS-UI/src/app/model/audit.ts
+++ b/EMS-UI/src/app/model/audit.ts
@@ -1,0 +1,5 @@
+export class Interaction {
+    caseId?: number;
+    requestOrigin: string;
+    createdDate: string;
+}

--- a/EMS-UI/src/app/model/audit.ts
+++ b/EMS-UI/src/app/model/audit.ts
@@ -1,5 +1,5 @@
 export class Interaction {
-    caseId?: number;
     requestOrigin: string;
-    createdDate: string;
+    createdDate: number; //instant
+    additionalProperties: Map<string, string> = new Map<string, string>();
 }

--- a/EMS-UI/src/app/model/cdssSupplier.ts
+++ b/EMS-UI/src/app/model/cdssSupplier.ts
@@ -1,4 +1,5 @@
-import { SupplierInstance } from './emsSupplier';
+import { SupplierInstance } from "./supplierInstance";
+
 export class CdssSupplier extends SupplierInstance{
   id: number;
   serviceDefinitions: ServiceDefinition[];

--- a/EMS-UI/src/app/model/cdssSupplier.ts
+++ b/EMS-UI/src/app/model/cdssSupplier.ts
@@ -1,7 +1,6 @@
-export class CdssSupplier {
+import { SupplierInstance } from './emsSupplier';
+export class CdssSupplier extends SupplierInstance{
   id: number;
-  name: string;
-  baseUrl: string;
   serviceDefinitions: ServiceDefinition[];
   inputParamsRefType: ResourceReferenceType;
   inputDataRefType: ResourceReferenceType;
@@ -9,6 +8,7 @@ export class CdssSupplier {
   authToken: string;
 
   constructor() {
+    super()
     this.id = 0;
     this.name = '';
     this.baseUrl = '';

--- a/EMS-UI/src/app/model/emsSupplier.ts
+++ b/EMS-UI/src/app/model/emsSupplier.ts
@@ -1,7 +1,4 @@
-export class SupplierInstance {
-    name: string;
-    baseUrl: string;
-}
+import { SupplierInstance } from "./supplierInstance";
 
 export class EmsSupplier extends SupplierInstance{
     id: number;

--- a/EMS-UI/src/app/model/emsSupplier.ts
+++ b/EMS-UI/src/app/model/emsSupplier.ts
@@ -1,6 +1,9 @@
-export class EmsSupplier {
-    id: number;
+export class SupplierInstance {
     name: string;
     baseUrl: string;
+}
+
+export class EmsSupplier extends SupplierInstance{
+    id: number;
     authToken: string;
 }

--- a/EMS-UI/src/app/model/index.ts
+++ b/EMS-UI/src/app/model/index.ts
@@ -17,3 +17,4 @@ export * from './token';
 export * from './user';
 export * from './emsSupplier';
 export * from './environment';
+export * from './audit'

--- a/EMS-UI/src/app/model/supplierInstance.ts
+++ b/EMS-UI/src/app/model/supplierInstance.ts
@@ -1,0 +1,4 @@
+export class SupplierInstance {
+    name: string;
+    baseUrl: string;
+}

--- a/EMS-UI/src/app/navigation/navigation.component.html
+++ b/EMS-UI/src/app/navigation/navigation.component.html
@@ -14,4 +14,6 @@
     <button mat-menu-item routerLink="/settings">Manage Settings</button>
     <button mat-menu-item routerLink="/view-audits">View Audits</button>
   </mat-menu>
+
+  <button class="homeButton" mat-button routerLink="/create_report">Validation</button>
 </div>

--- a/EMS-UI/src/app/service/audit.service.spec.ts
+++ b/EMS-UI/src/app/service/audit.service.spec.ts
@@ -1,0 +1,66 @@
+import { Interaction } from './../model/audit';
+import { HttpClient } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+import { AuditService } from './audit.service';
+import { asyncData } from '../testing/async-observable-helpers';
+import { SESSION_STORAGE_OBJECT, SessionStorage, SERDES_OBJECT, STORAGE_OPTIONS } from 'h5webstorage';
+
+xdescribe('Audit Service', () => {
+
+    let httpClientSpy: { get: jasmine.Spy};
+    let auditService: AuditService;
+
+    beforeEach(() => {
+        httpClientSpy = jasmine.createSpyObj('HttpClient', ['get']);
+        TestBed.configureTestingModule({
+            providers: [
+                {provide: HttpClient, useValue: httpClientSpy},
+                // TODO: this is not working, tests are disabled for now. CDSCT-336
+                {provide: SESSION_STORAGE_OBJECT, useValue: {"auth_token": "testtoken"}},
+                {provide: SERDES_OBJECT, useValue: {stringify: JSON.stringify, parse: JSON.parse}},
+                {provide: STORAGE_OPTIONS, useValue: {}},
+                SessionStorage,
+                AuditService,
+            ]
+        });
+        auditService = TestBed.get(AuditService);
+    });
+
+    it('should get encounter audits', () => {
+        const expectedInteraction: Interaction = {
+            requestOrigin: "http://a-place.com",
+            createdDate: 835222942,
+            additionalProperties: new Map([['caseId', '4']])
+        };
+
+        httpClientSpy.get.and.returnValue(asyncData(expectedInteraction));
+
+        auditService.getEncounterAudits()
+            .then(interactionArray => {
+                expect(interactionArray)
+                    .toContain(expectedInteraction, 'expected interaction');
+            })
+            .catch(fail);
+        expect(httpClientSpy.get.calls.count()).toBe(1, 'one call');
+        //TODO: complete CDSCT-336
+    });
+
+    it('should get service definition search audits', () => {
+        const expectedInteraction: Interaction = {
+            requestOrigin: "http://another-place.com",
+            createdDate: 835222942,
+            additionalProperties: new Map([])
+        };
+
+        httpClientSpy.get.and.returnValue(asyncData(expectedInteraction));
+
+        auditService.getServiceDefinitionSearchAudits()
+            .then(interactionArray => {
+                expect(interactionArray)
+                    .toContain(expectedInteraction, 'expected interaction');
+            })
+            .catch(fail);
+        expect(httpClientSpy.get.calls.count()).toBe(1, 'one call');
+        //TODO: complete CDSCT-336
+    });
+})

--- a/EMS-UI/src/app/service/audit.service.ts
+++ b/EMS-UI/src/app/service/audit.service.ts
@@ -29,7 +29,6 @@ export class AuditService {
   }
 
   getEncounterAudits(): Promise<Interaction[]> {
-    console.log("Got here");
     if (this.sessionStorage['auth_token'] != null) {
       httpOptions.headers = httpOptions.headers.set(
         'Authorization',

--- a/EMS-UI/src/app/service/audit.service.ts
+++ b/EMS-UI/src/app/service/audit.service.ts
@@ -28,14 +28,27 @@ export class AuditService {
     }
   }
 
-  getEncounterAudits(): Observable<Interaction[]> {
-    let int1: Interaction = {createdDate: "2020-06-23", caseId: 4, requestOrigin: "https://cdss.com/fhir/ServiceDefinition/initial.initial/$evaluate..."};
-    return of([int1]);
+  getEncounterAudits(): Promise<Interaction[]> {
+    console.log("Got here");
+    if (this.sessionStorage['auth_token'] != null) {
+      httpOptions.headers = httpOptions.headers.set(
+        'Authorization',
+        this.sessionStorage['auth_token']
+      );
+      const url = `${environment.EMS_API}/audit/encounters/`;
+      return this.http.get<Interaction[]>(url, httpOptions).toPromise();
+    }
   }
 
-  getServiceDefinitionSearchAudits(): Observable<Interaction[]> {
-    let int1: Interaction = {createdDate: "2020-06-23", requestOrigin: "https://cdss.com/fhir/ServiceDefinition?..."};
-    return of([int1]);
+  getServiceDefinitionSearchAudits(): Promise<Interaction[]> {
+    if (this.sessionStorage['auth_token'] != null) {
+      httpOptions.headers = httpOptions.headers.set(
+        'Authorization',
+        this.sessionStorage['auth_token']
+      );
+      const url = `${environment.EMS_API}/audit/servicesearches/`;
+      return this.http.get<Interaction[]>(url, httpOptions).toPromise();
+    }
   }
 
   searchAudits(fromDate: any, toDate: any, pageNumber: any, pageSize: any, includeClosed: boolean, includeIncomplete: boolean) {

--- a/EMS-UI/src/app/service/audit.service.ts
+++ b/EMS-UI/src/app/service/audit.service.ts
@@ -1,8 +1,10 @@
+import { Observable, of } from 'rxjs';
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { environment } from '../../environments/environment';
 import { Token } from '../model/token';
 import { SessionStorage } from 'h5webstorage';
+import { Interaction } from '../model';
 
 const httpOptions = {
   headers: new HttpHeaders()
@@ -24,6 +26,16 @@ export class AuditService {
       const url = `${environment.EMS_API}/audit/${id}`;
       return this.http.get<any>(url, httpOptions).toPromise();
     }
+  }
+
+  getEncounterAudits(): Observable<Interaction[]> {
+    let int1: Interaction = {createdDate: "2020-06-23", caseId: 4, requestOrigin: "https://cdss.com/fhir/ServiceDefinition/initial.initial/$evaluate..."};
+    return of([int1]);
+  }
+
+  getServiceDefinitionSearchAudits(): Observable<Interaction[]> {
+    let int1: Interaction = {createdDate: "2020-06-23", requestOrigin: "https://cdss.com/fhir/ServiceDefinition?..."};
+    return of([int1]);
   }
 
   searchAudits(fromDate: any, toDate: any, pageNumber: any, pageSize: any, includeClosed: boolean, includeIncomplete: boolean) {

--- a/EMS-UI/src/app/validation-report/validation-report.component.css
+++ b/EMS-UI/src/app/validation-report/validation-report.component.css
@@ -1,0 +1,43 @@
+h4 {
+    text-align: center;
+    padding: 10px;
+}
+
+
+.header {
+    margin-top: 20px;
+    padding: 10px 20px;
+    background-color: #005EB8;
+    color: white;
+}
+
+.endpoints, .interactions {
+    font-family: Arial, Helvetica, sans-serif;
+    font-size: 13px;
+    padding: 1%;
+    border-color: lightgrey;
+    border-style: solid;
+    border-width: 0 1px 1px 1px;
+    white-space: nowrap;
+}
+
+.endpoints tr, .interactions tr {
+    border-bottom: 1px solid lightgrey;
+}
+
+.actionButton {
+    background-color: white;
+    border: 2px solid #425563;
+    padding: 5px 25px;
+    margin-left: 10px;
+    cursor: pointer;
+}
+
+.actionButton:hover {
+    background-color: lightgray;
+    color: white;
+}
+
+.actions {
+    float: right;
+}

--- a/EMS-UI/src/app/validation-report/validation-report.component.html
+++ b/EMS-UI/src/app/validation-report/validation-report.component.html
@@ -40,7 +40,7 @@
           <tbody>
             <tr class="interaction" *ngFor="let interaction of interactions">
               <td class="interactionRequestOrigin">{{ interaction.requestOrigin }}</td>
-              <td class="interactionCreatedDate">{{ interaction.createdDate * 1000 | date:'medium' }}</td>
+              <td class="interactionCreatedDate">{{ interaction.createdDate * 1000 | date:'medium':'UTC' }}</td>
               <td class="interactionCaseId">{{ interaction.additionalProperties["caseId"] }}</td>
             </tr>
           </tbody>

--- a/EMS-UI/src/app/validation-report/validation-report.component.html
+++ b/EMS-UI/src/app/validation-report/validation-report.component.html
@@ -1,10 +1,10 @@
 <h4>Request Validation Report</h4>
-<div class="container-fluid" *ngIf="!error && loaded">
+<div class="container-fluid" *ngIf="loaded">
   <div class="row">
     <div class="col-xs-12 col-md-10 offset-md-1">
       <div class="header">Select a registered endpoint</div>
       <mat-progress-bar mode="indeterminate" *ngIf="!loaded"></mat-progress-bar>
-      <div *ngIf="!error && loaded" class="endpoints table-responsive">
+      <div *ngIf="loaded" class="endpoints table-responsive">
         <table class="table table-borderless table-hover">
           <thead>
             <tr>
@@ -20,9 +20,6 @@
             </tr>
           </tbody>
         </table>
-      </div>
-      <div class="alert alert-danger" *ngIf="error">
-            <app-error-display [(errorObject)]="error"></app-error-display>
       </div>
     </div>
   </div>
@@ -41,16 +38,13 @@
             </tr>
           </thead>
           <tbody>
-            <tr class="emsSupplier" *ngFor="let interaction of interactions">
-              <td>{{ interaction.requestOrigin }}</td>
-              <td>{{ interaction.createdDate }}</td>
-              <td>{{ interaction.caseId }}</td>
+            <tr class="interaction" *ngFor="let interaction of interactions">
+              <td class="interactionRequestOrigin">{{ interaction.requestOrigin }}</td>
+              <td class="interactionCreatedDate">{{ interaction.createdDate }}</td>
+              <td class="interactionCaseId">{{ interaction.caseId }}</td>
             </tr>
           </tbody>
         </table>
-      </div>
-      <div class="alert alert-danger" *ngIf="error">
-            <app-error-display [(errorObject)]="error"></app-error-display>
       </div>
     </div>
   </div>

--- a/EMS-UI/src/app/validation-report/validation-report.component.html
+++ b/EMS-UI/src/app/validation-report/validation-report.component.html
@@ -40,8 +40,8 @@
           <tbody>
             <tr class="interaction" *ngFor="let interaction of interactions">
               <td class="interactionRequestOrigin">{{ interaction.requestOrigin }}</td>
-              <td class="interactionCreatedDate">{{ interaction.createdDate }}</td>
-              <td class="interactionCaseId">{{ interaction.caseId }}</td>
+              <td class="interactionCreatedDate">{{ interaction.createdDate * 1000 | date:'medium' }}</td>
+              <td class="interactionCaseId">{{ interaction.additionalProperties["caseId"] }}</td>
             </tr>
           </tbody>
         </table>

--- a/EMS-UI/src/app/validation-report/validation-report.component.html
+++ b/EMS-UI/src/app/validation-report/validation-report.component.html
@@ -1,0 +1,58 @@
+<h4>Request Validation Report</h4>
+<div class="container-fluid" *ngIf="!error && loaded">
+  <div class="row">
+    <div class="col-xs-12 col-md-10 offset-md-1">
+      <div class="header">Select a registered endpoint</div>
+      <mat-progress-bar mode="indeterminate" *ngIf="!loaded"></mat-progress-bar>
+      <div *ngIf="!error && loaded" class="endpoints table-responsive">
+        <table class="table table-borderless table-hover">
+          <thead>
+            <tr>
+              <th scope="col">Name</th>
+              <th scope="col">URL</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr class="endpoint" *ngFor="let endpoint of endpoints">
+              <td class="endpointName">{{ endpoint.name }}</td>
+              <td class="endpointBaseUrl">{{ endpoint.baseUrl }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="alert alert-danger" *ngIf="error">
+            <app-error-display [(errorObject)]="error"></app-error-display>
+      </div>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-xs-12 col-md-10 offset-md-1">
+      <div class="header">Select interactions</div>
+      <div class="table-responsive interactions">
+        <table class="table table-borderless table-hover">
+          <thead>
+            <tr>
+              <th scope="col">URL</th>
+              <th scope="col">Date</th>
+              <th scope="col">Case ID</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr class="emsSupplier" *ngFor="let interaction of interactions">
+              <td>{{ interaction.requestOrigin }}</td>
+              <td>{{ interaction.createdDate }}</td>
+              <td>{{ interaction.caseId }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="alert alert-danger" *ngIf="error">
+            <app-error-display [(errorObject)]="error"></app-error-display>
+      </div>
+    </div>
+  </div>
+</div>
+  

--- a/EMS-UI/src/app/validation-report/validation-report.component.spec.ts
+++ b/EMS-UI/src/app/validation-report/validation-report.component.spec.ts
@@ -111,11 +111,11 @@ describe('ValidationReportComponent', () => {
   it('should display interactions', fakeAsync(() => {
     let encounter = new Interaction();
     encounter.additionalProperties["caseId"] = 4;
-    encounter.createdDate = 835222942; //'Jun 19, 1996, 11:22:22 PM'
+    encounter.createdDate = 835222942; //'Jun 19, 1996, 10:22:22 PM'
     encounter.requestOrigin = "https://some-encounter-location/fhir";
 
     let sdSearch = new Interaction();
-    sdSearch.createdDate = 955335783; //'Apr 10, 2000, 4:03:03 AM'
+    sdSearch.createdDate = 955335783; //'Apr 10, 2000, 3:03:03 AM'
     sdSearch.requestOrigin = "https://some-service-location/fhir";
 
     cdssServiceSpy.getCdssSuppliers.and.returnValue(of([]));
@@ -129,8 +129,8 @@ describe('ValidationReportComponent', () => {
 
     expect(comp.loaded).toBeTruthy();
     expect(page.interactions).toContain(
-      {origin: encounter.requestOrigin, createdDate: 'Jun 19, 1996, 11:22:22 PM', caseId: encounter.additionalProperties['caseId']},
-      {origin: sdSearch.requestOrigin, createdDate: 'Apr 10, 2000, 4:03:03 AM', caseId: 0}
+      {origin: encounter.requestOrigin, createdDate: 'Jun 19, 1996, 10:22:22 PM', caseId: encounter.additionalProperties['caseId']},
+      {origin: sdSearch.requestOrigin, createdDate: 'Apr 10, 2000, 3:03:03 AM', caseId: 0}
     );
   }));
 

--- a/EMS-UI/src/app/validation-report/validation-report.component.spec.ts
+++ b/EMS-UI/src/app/validation-report/validation-report.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ValidationReportComponent } from './validation-report.component';
+
+describe('ValidationReportComponent', () => {
+  let component: ValidationReportComponent;
+  let fixture: ComponentFixture<ValidationReportComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ValidationReportComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ValidationReportComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/EMS-UI/src/app/validation-report/validation-report.component.spec.ts
+++ b/EMS-UI/src/app/validation-report/validation-report.component.spec.ts
@@ -1,25 +1,143 @@
+import { Interaction } from './../model/audit';
+import { EmsSupplier } from './../model/emsSupplier';
+import { CdssSupplier } from 'src/app/model/cdssSupplier';
+import { of } from 'rxjs';
+import { AuditService } from './../service/audit.service';
+import { EmsService } from './../service/ems.service';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ValidationReportComponent } from './validation-report.component';
+import { Predicate, DebugElement, Component, Input } from '@angular/core';
+import { CdssService } from '../service';
+import { MaterialModule } from '../material.module';
+import { By } from '@angular/platform-browser';
 
-describe('ValidationReportComponent', () => {
-  let component: ValidationReportComponent;
-  let fixture: ComponentFixture<ValidationReportComponent>;
+@Component({selector: 'app-error-display', template: ''})
+class ErrorDisplayStub {
+    @Input('errorObject')
+    public errorObject: any;
+}
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ ValidationReportComponent ]
-    })
-    .compileComponents();
-  }));
+let comp: ValidationReportComponent;
+let fixture: ComponentFixture<ValidationReportComponent>;
+let page: ValidationReportComponentPage;
+
+class ValidationReportComponentPage {
+
+  get endpoints() {
+    const rows = this.queryAll(By.css('.endpoint'));
+    return rows.map(row => {
+      const name = row.query(By.css('.endpointName')).nativeElement.innerText;
+      const baseUrl = row.query(By.css('.endpointBaseUrl')).nativeElement.innerText;
+
+      return {name, baseUrl};
+    });
+  }
+
+  get interactions() {
+    const rows = this.queryAll(By.css('.interaction'));
+    return rows.map(row => {
+      const origin = row.query(By.css('.interactionRequestOrigin')).nativeElement.innerText;
+      const createdDate = row.query(By.css('.interactionCreatedDate')).nativeElement.innerText;
+      const caseId: number = +row.query(By.css('.interactionCaseId')).nativeElement.innerText;
+
+      return {origin, createdDate, caseId};
+    });
+  }
+
+  private queryAll(by: Predicate<DebugElement>): DebugElement[] {
+    return fixture.debugElement.queryAll(by);
+  }
+}
+
+fdescribe('ValidationReportComponent', () => {
+
+  let emsServiceSpy: { getAllEmsSuppliers: jasmine.Spy };
+  let cdssServiceSpy: { getCdssSuppliers: jasmine.Spy };
+  let auditServiceSpy: { 
+    getEncounterAudits: jasmine.Spy, 
+    getServiceDefinitionSearchAudits: jasmine.Spy
+  }
 
   beforeEach(() => {
+    emsServiceSpy = jasmine.createSpyObj('EmsService', ['getAllEmsSuppliers']);
+    cdssServiceSpy = jasmine.createSpyObj('CdssService', ['getCdssSuppliers']);
+    auditServiceSpy = jasmine.createSpyObj('AuditService', 
+      ['getEncounterAudits', 'getServiceDefinitionSearchAudits']);
+
+    TestBed.configureTestingModule({
+        imports: [MaterialModule],
+        declarations: [ValidationReportComponent, ErrorDisplayStub],
+        providers: [
+            {provide: CdssService, useValue: cdssServiceSpy},
+            {provide: EmsService, useValue: emsServiceSpy},
+            {provide: AuditService, useValue: auditServiceSpy}
+        ]
+    });
     fixture = TestBed.createComponent(ValidationReportComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+    comp = fixture.componentInstance;
+    page = new ValidationReportComponentPage();
   });
 
   it('should create', () => {
-    expect(component).toBeTruthy();
+    expect(comp).toBeTruthy();
+  });
+
+  it('should display end points', () => {
+    let cdss = new CdssSupplier();
+    cdss.name = "A cdss name";
+    cdss.baseUrl = "http://cdss.base.url/fhir";
+
+    let ems = new EmsSupplier();
+    ems.name = "An ems name";
+    ems.baseUrl = "http://ems.base.url/fhir";
+
+    cdssServiceSpy.getCdssSuppliers.and.returnValue(of([cdss]));
+    emsServiceSpy.getAllEmsSuppliers.and.returnValue(of([ems]));
+    auditServiceSpy.getEncounterAudits.and.returnValue(of([]));
+    auditServiceSpy.getServiceDefinitionSearchAudits.and.returnValue(of([]));
+
+    fixture.detectChanges(); // init
+
+    expect(comp.loaded).toBeTruthy();
+    expect(page.endpoints).toContain(
+      {name: cdss.name, baseUrl: cdss.baseUrl}, 
+      {name: ems.name, baseUrl: ems.baseUrl}
+    );
+  });
+
+  it('should display interactions', () => {
+    let encounter = new Interaction();
+    encounter.caseId = 4;
+    encounter.createdDate = "23/06/2020 12:12:12";
+    encounter.requestOrigin = "https://some-encounter-location/fhir";
+
+    let sdSearch = new Interaction();
+    sdSearch.createdDate = "23/06/2020 12:12:10";
+    sdSearch.requestOrigin = "https://some-service-location/fhir";
+
+    cdssServiceSpy.getCdssSuppliers.and.returnValue(of([]));
+    emsServiceSpy.getAllEmsSuppliers.and.returnValue(of([]));
+    auditServiceSpy.getEncounterAudits.and.returnValue(of([encounter]));
+    auditServiceSpy.getServiceDefinitionSearchAudits.and.returnValue(of([sdSearch]));
+
+    fixture.detectChanges(); // init
+
+    expect(comp.loaded).toBeTruthy();
+    expect(page.interactions).toContain(
+      {origin: encounter.requestOrigin, createdDate: encounter.createdDate, caseId: encounter.caseId},
+      {origin: sdSearch.requestOrigin, createdDate: sdSearch.createdDate, caseId: ''}
+    );
+  });
+
+  it('should not display when loading fails', () => {
+    cdssServiceSpy.getCdssSuppliers.and.returnValue(of());
+    emsServiceSpy.getAllEmsSuppliers.and.returnValue(of());
+    auditServiceSpy.getEncounterAudits.and.returnValue(of());
+    auditServiceSpy.getServiceDefinitionSearchAudits.and.returnValue(of());
+
+    fixture.detectChanges(); // init
+
+    expect(comp.loaded).toBeFalsy();
   });
 });

--- a/EMS-UI/src/app/validation-report/validation-report.component.spec.ts
+++ b/EMS-UI/src/app/validation-report/validation-report.component.spec.ts
@@ -99,7 +99,7 @@ describe('ValidationReportComponent', () => {
 
     fixture.detectChanges(); // init
     tick();
-    fixture.detectChanges();
+    fixture.detectChanges(); // resolve async promises
 
     expect(comp.loaded).toBeTruthy();
     expect(page.endpoints).toContain(
@@ -108,14 +108,14 @@ describe('ValidationReportComponent', () => {
     );
   }));
 
-  fit('should display interactions', fakeAsync(() => {
+  it('should display interactions', fakeAsync(() => {
     let encounter = new Interaction();
     encounter.additionalProperties["caseId"] = 4;
-    encounter.createdDate = +Date.parse("2011-10-10T14:48");
+    encounter.createdDate = 835222942; //'Jun 19, 1996, 11:22:22 PM'
     encounter.requestOrigin = "https://some-encounter-location/fhir";
 
     let sdSearch = new Interaction();
-    sdSearch.createdDate = +Date.parse("2011-10-10T14:48:00");
+    sdSearch.createdDate = 955335783; //'Apr 10, 2000, 4:03:03 AM'
     sdSearch.requestOrigin = "https://some-service-location/fhir";
 
     cdssServiceSpy.getCdssSuppliers.and.returnValue(of([]));
@@ -125,12 +125,12 @@ describe('ValidationReportComponent', () => {
 
     fixture.detectChanges(); // init
     tick();
-    fixture.detectChanges();
+    fixture.detectChanges(); // resolve async promises
 
     expect(comp.loaded).toBeTruthy();
     expect(page.interactions).toContain(
-      {origin: encounter.requestOrigin, createdDate: encounter.createdDate, caseId: encounter.additionalProperties['caseId']},
-      {origin: sdSearch.requestOrigin, createdDate: sdSearch.createdDate, caseId: 0}
+      {origin: encounter.requestOrigin, createdDate: 'Jun 19, 1996, 11:22:22 PM', caseId: encounter.additionalProperties['caseId']},
+      {origin: sdSearch.requestOrigin, createdDate: 'Apr 10, 2000, 4:03:03 AM', caseId: 0}
     );
   }));
 

--- a/EMS-UI/src/app/validation-report/validation-report.component.ts
+++ b/EMS-UI/src/app/validation-report/validation-report.component.ts
@@ -1,0 +1,85 @@
+import { SupplierInstance } from './../model/emsSupplier';
+import { Interaction } from './../model/audit';
+import { AuditService } from './../service/audit.service';
+import { CdssSupplier } from './../model/cdssSupplier';
+import { Component, OnInit } from '@angular/core';
+import { EmsService } from '../service/ems.service';
+import { EmsSupplier } from '../model';
+import { CdssService } from '../service';
+
+@Component({
+  selector: 'validation-report',
+  templateUrl: './validation-report.component.html',
+  styleUrls: ['./validation-report.component.css']
+})
+export class ValidationReportComponent implements OnInit {
+
+  endpoints: SupplierInstance[] = [];
+  loadedEms = false;
+  loadedCdss = false;
+  interactions: Interaction[] = [];
+  loadedEncounterAudits = false;
+  loadedSearchAudits = false;
+
+  error: any;
+
+  constructor(
+    private emsService: EmsService, 
+    private cdssService: CdssService,
+    private auditService: AuditService
+  ) { }
+
+  ngOnInit() {
+    this.fetchEndpoints();
+    this.fetchAudits();
+  }
+
+  get loaded() {
+    return this.error || 
+      (this.loadedCdss 
+        && this.loadedEms 
+        && this.loadedEncounterAudits 
+        && this.loadedSearchAudits);
+  }
+
+  fetchEndpoints() {
+    this.emsService.getAllEmsSuppliers()
+      .subscribe(
+        suppliers => {
+          this.endpoints = this.endpoints.concat(suppliers);
+          this.loadedEms = true;
+        },
+        error => this.error = error
+      );
+    this.cdssService.getCdssSuppliers()
+      .subscribe(
+        suppliers => {
+          this.endpoints = this.endpoints.concat(suppliers);
+          this.loadedCdss = true;
+        },
+        error => this.error = error
+      );
+  }
+
+  fetchAudits() {
+    this.auditService.getEncounterAudits()
+      .subscribe(
+        interactions => {
+          this.interactions = this.interactions.concat(interactions);
+          this.loadedEncounterAudits = true;
+        },
+        error => this.error = error
+      );
+    this.auditService.getServiceDefinitionSearchAudits()
+      .subscribe(
+        interactions => {
+          this.interactions = this.interactions.concat(interactions);
+          this.loadedSearchAudits = true;
+        },
+        error => this.error = error
+      );
+  }
+
+
+
+}

--- a/EMS-UI/src/app/validation-report/validation-report.component.ts
+++ b/EMS-UI/src/app/validation-report/validation-report.component.ts
@@ -21,8 +21,6 @@ export class ValidationReportComponent implements OnInit {
   loadedEncounterAudits = false;
   loadedSearchAudits = false;
 
-  error: any;
-
   constructor(
     private emsService: EmsService, 
     private cdssService: CdssService,
@@ -35,11 +33,10 @@ export class ValidationReportComponent implements OnInit {
   }
 
   get loaded() {
-    return this.error || 
-      (this.loadedCdss 
+    return this.loadedCdss 
         && this.loadedEms 
         && this.loadedEncounterAudits 
-        && this.loadedSearchAudits);
+        && this.loadedSearchAudits;
   }
 
   fetchEndpoints() {
@@ -48,16 +45,14 @@ export class ValidationReportComponent implements OnInit {
         suppliers => {
           this.endpoints = this.endpoints.concat(suppliers);
           this.loadedEms = true;
-        },
-        error => this.error = error
+        }
       );
     this.cdssService.getCdssSuppliers()
       .subscribe(
         suppliers => {
           this.endpoints = this.endpoints.concat(suppliers);
           this.loadedCdss = true;
-        },
-        error => this.error = error
+        }
       );
   }
 
@@ -67,16 +62,14 @@ export class ValidationReportComponent implements OnInit {
         interactions => {
           this.interactions = this.interactions.concat(interactions);
           this.loadedEncounterAudits = true;
-        },
-        error => this.error = error
+        }
       );
     this.auditService.getServiceDefinitionSearchAudits()
       .subscribe(
         interactions => {
           this.interactions = this.interactions.concat(interactions);
           this.loadedSearchAudits = true;
-        },
-        error => this.error = error
+        }
       );
   }
 

--- a/EMS-UI/src/app/validation-report/validation-report.component.ts
+++ b/EMS-UI/src/app/validation-report/validation-report.component.ts
@@ -63,13 +63,14 @@ export class ValidationReportComponent implements OnInit {
           this.interactions = this.interactions.concat(interactions);
           this.loadedEncounterAudits = true;
         }
-      );
+      )
+      .catch(err => this.loadedEncounterAudits = true);
     this.auditService.getServiceDefinitionSearchAudits()
       .then(
         interactions => {
           this.interactions = this.interactions.concat(interactions);
           this.loadedSearchAudits = true;
         }
-      );
+      ).catch(err => this.loadedEncounterAudits = true);
   }
 }

--- a/EMS-UI/src/app/validation-report/validation-report.component.ts
+++ b/EMS-UI/src/app/validation-report/validation-report.component.ts
@@ -1,11 +1,9 @@
-import { SupplierInstance } from './../model/emsSupplier';
 import { Interaction } from './../model/audit';
 import { AuditService } from './../service/audit.service';
-import { CdssSupplier } from './../model/cdssSupplier';
 import { Component, OnInit } from '@angular/core';
 import { EmsService } from '../service/ems.service';
-import { EmsSupplier } from '../model';
 import { CdssService } from '../service';
+import { SupplierInstance } from '../model/supplierInstance';
 
 @Component({
   selector: 'validation-report',

--- a/EMS-UI/src/app/validation-report/validation-report.component.ts
+++ b/EMS-UI/src/app/validation-report/validation-report.component.ts
@@ -58,21 +58,18 @@ export class ValidationReportComponent implements OnInit {
 
   fetchAudits() {
     this.auditService.getEncounterAudits()
-      .subscribe(
+      .then(
         interactions => {
           this.interactions = this.interactions.concat(interactions);
           this.loadedEncounterAudits = true;
         }
       );
     this.auditService.getServiceDefinitionSearchAudits()
-      .subscribe(
+      .then(
         interactions => {
           this.interactions = this.interactions.concat(interactions);
           this.loadedSearchAudits = true;
         }
       );
   }
-
-
-
 }

--- a/EMS-UI/src/app/validation-report/validation-report.component.ts
+++ b/EMS-UI/src/app/validation-report/validation-report.component.ts
@@ -64,6 +64,7 @@ export class ValidationReportComponent implements OnInit {
           this.loadedEncounterAudits = true;
         }
       )
+      //TODO: handle errors properly
       .catch(err => this.loadedEncounterAudits = true);
     this.auditService.getServiceDefinitionSearchAudits()
       .then(
@@ -71,6 +72,7 @@ export class ValidationReportComponent implements OnInit {
           this.interactions = this.interactions.concat(interactions);
           this.loadedSearchAudits = true;
         }
-      ).catch(err => this.loadedEncounterAudits = true);
+        //TODO: handle errors properly
+      ).catch(err => this.loadedSearchAudits = true);
   }
 }

--- a/src/main/java/uk/nhs/ctp/auditFinder/finder/AWSAuditFinder.java
+++ b/src/main/java/uk/nhs/ctp/auditFinder/finder/AWSAuditFinder.java
@@ -1,7 +1,11 @@
 package uk.nhs.ctp.auditFinder.finder;
 
+import static org.apache.commons.lang3.ObjectUtils.isNotEmpty;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -14,11 +18,6 @@ import org.springframework.stereotype.Service;
 import uk.nhs.cactus.common.security.TokenAuthenticationService;
 import uk.nhs.ctp.audit.model.AuditSession;
 import uk.nhs.ctp.auditFinder.ElasticSearchClient;
-
-import java.util.List;
-import java.util.stream.Collectors;
-
-import static org.apache.commons.lang3.ObjectUtils.isNotEmpty;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/uk/nhs/ctp/controllers/AuditController.java
+++ b/src/main/java/uk/nhs/ctp/controllers/AuditController.java
@@ -1,16 +1,26 @@
 package uk.nhs.ctp.controllers;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.time.ZoneOffset;
+import java.util.Collections;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.domain.Page;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import uk.nhs.ctp.audit.model.AuditSession;
 import uk.nhs.ctp.auditFinder.finder.AuditFinder;
 import uk.nhs.ctp.caseSearch.CaseSearchRequest;
 import uk.nhs.ctp.caseSearch.CaseSearchResultDTO;
 import uk.nhs.ctp.caseSearch.CaseSearchService;
-
-import java.io.IOException;
 
 @CrossOrigin
 @RestController
@@ -22,9 +32,36 @@ public class AuditController {
 	private final AuditFinder auditFinder;
 	private final CaseSearchService caseSearchService;
 
+	/**
+	 * Retrieve all audit sessions for a given case ID.
+	 * Because this search requires the case id property existing, this will return sessions during a triage, namely: $evaluate.
+	 * @param id Case ID to search on
+	 * @return list of Audit Sessions
+	 */
 	@GetMapping(path = "/{id}")
 	public String getAudit(@PathVariable Long id) throws IOException {
 		return mapper.writeValueAsString(auditFinder.findAll(id));
+	}
+
+	@GetMapping(path = "/encounters")
+	public List<AuditSession> getAuditEncounters() {
+		return Collections.singletonList(
+				AuditSession.builder()
+						.additionalProperty("caseId", "4")
+						.createdDate(LocalDateTime.of(2020, Month.JUNE, 19, 15, 30).toInstant(ZoneOffset.UTC))
+						.requestOrigin("http://hardcoded-encounter-origin/fhir")
+						.build()
+		);
+	}
+
+	@GetMapping(path = "/servicesearches")
+	public List<AuditSession> getAuditServiceSearch() {
+		return Collections.singletonList(
+				AuditSession.builder()
+						.createdDate(LocalDateTime.of(2020, Month.JUNE, 19, 15, 30).toInstant(ZoneOffset.UTC))
+						.requestOrigin("http://hardcoded-search-origin/fhir")
+						.build()
+		);
 	}
 	
 	@PostMapping


### PR DESCRIPTION
New ui page displays endpoints and interactions.
Tests for audit.service.spec.ts are disabled due to session storage dependency not injecting properly.
I've included a dummy endpoint just to make sure they can communicate properly: I guess this is subject to change.