### PR TITLE
Case-insensitive content-type header name check

### DIFF
--- a/src/main/java/uk/nhs/ctp/audit/AuditParser.java
+++ b/src/main/java/uk/nhs/ctp/audit/AuditParser.java
@@ -16,7 +16,7 @@ public class AuditParser {
         .map(header -> header.split(":"))
         .filter(headerParts -> headerParts.length == 2)
         .collect(Collectors.toUnmodifiableMap(
-            headerParts -> headerParts[0],
+            headerParts -> headerParts[0].toLowerCase(),
             headerParts -> getHeaderValueFrom(headerParts[1])
         ));
   }

--- a/src/test/resources/stubbyEncounterAudit.json
+++ b/src/test/resources/stubbyEncounterAudit.json
@@ -7,7 +7,7 @@
   "requestHeaders": "content-type: [application/fhir+xml]",
   "responseStatus": "200",
   "responseBody": "auditResponseBody",
-  "responseHeaders": "content-type: [application/fhir+json]",
+  "responseHeaders": "Content-Type: [application/fhir+json]",
   "createdDate": "2020-06-30T07:56:31.467917Z",
   "entries": [
     {


### PR DESCRIPTION
Ensured that the content-type header names are checked in a case-insensitive way when selecting audits for validation.