### PR TITLE
Fix for retrieving ems audits

### DIFF
--- a/EMS-UI/src/app/validation-report/validation-report.component.html
+++ b/EMS-UI/src/app/validation-report/validation-report.component.html
@@ -41,7 +41,7 @@
             <tr>
               <th scope="col">Type</th>
               <th scope="col">Date</th>
-              <th scope="col">Case ID</th>
+              <th scope="col">Interaction ID</th>
               <th></th>
             </tr>
           </thead>

--- a/src/main/java/uk/nhs/ctp/auditFinder/AuditFinder.java
+++ b/src/main/java/uk/nhs/ctp/auditFinder/AuditFinder.java
@@ -13,6 +13,7 @@ import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.sort.FieldSortBuilder;
 import org.elasticsearch.search.sort.SortOrder;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.nhs.cactus.common.audit.model.AuditSession;
 import uk.nhs.cactus.common.audit.model.OperationType;
@@ -25,8 +26,6 @@ public class AuditFinder {
 
   private static final int MAX_RETURNED_AUDITS = 100;
 
-  private static final String EMS_NAME = "ems.cactus-staging";
-
   private static final String OWNER_FIELD = "@owner.keyword";
   private static final String TIMESTAMP_FIELD = "@timestamp";
   private static final String SUPPLIER_ID_FIELD = "additionalProperties.supplierId";
@@ -34,6 +33,9 @@ public class AuditFinder {
   private static final String OPERATION_FIELD = "additionalProperties.operation";
 
   private static final String AUDIT_SUFFIX = "-audit";
+
+  @Value("${service.name}")
+  private String emsName;
 
   private final ElasticSearchClient esClient;
   private final TokenAuthenticationService authenticationService;
@@ -57,7 +59,7 @@ public class AuditFinder {
     var supplierId = authenticationService.requireSupplierId();
 
     var query = QueryBuilders.boolQuery()
-        .must(QueryBuilders.termQuery(OWNER_FIELD, EMS_NAME))
+        .must(QueryBuilders.termQuery(OWNER_FIELD, emsName))
         .must(QueryBuilders.termQuery(SUPPLIER_ID_FIELD, supplierId))
         .must(QueryBuilders.termQuery(INTERACTION_ID_FIELD, caseId));
 


### PR DESCRIPTION
Previously the EMS expected a hardcoded @owner name in the triage audits. It will now expect the same @owner name as what the EMS service name is set to in the environment variables.
Also updated a UI column name.